### PR TITLE
feat(design): impr navbar__title w small desktops

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -126,3 +126,9 @@ table {
 [data-theme='dark'] .frontpageSvgButton {
   filter: invert(100%);
 }
+
+@media screen and (max-width: 1200px) {
+  .navbar__title {
+    width: 0;
+  }
+}


### PR DESCRIPTION
For small desktops, but before docusaurus responsive mobile view kicks
in the navbar title is covered.
