### PR TITLE
Merge 'develop' into master (minor hotfix)

### DIFF
--- a/docs/developers/strat-lib/getting-started/smart-offer.md
+++ b/docs/developers/strat-lib/getting-started/smart-offer.md
@@ -46,7 +46,7 @@ The abstract contract `Direct` has internal functions that allows one to manage 
 
 > See [OfferArgs](../technical-references/code/strats/src/strategies/interfaces/IOfferLogic.md#offerargs) for an explanation of the parameters for posting an offer.
 
-> Also see %%provision|provision%%, %%gasreq|gasreq%%, and TODO:%pivotId|pivot-id%, and %%offer list|offer-list%%.
+> Also see %%provision|provision%%, %%gasreq|gasreq%%, and %%offer list|offer-list%%.
 
 Add the below code to your contract.
 


### PR DESCRIPTION
Removing an old term.